### PR TITLE
Install formatters and use them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 set(GITHUB_ORGANIZATION "SDHCAL")
 set(PROJECT_NAME "streamout")
@@ -10,15 +10,12 @@ configure_file("${CMAKE_SOURCE_DIR}/docs/README.md.in" "${CMAKE_SOURCE_DIR}/READ
 # Download CMakeCM
 set(DOWNLOAD_CMAKECM_URL "https://raw.githubusercontent.com/flagarde/CMakeCM/master/DownloadCMakeCM.cmake" CACHE STRING "URL of the CMakeCM package")
 set(DOWNLOAD_CMAKECM_SHA256 "f30eca2c1bc5ff6bc4b314b0abd9b1ea5999ed874e2a710fb0f5ccd5db7b3963" CACHE STRING "SHA256 of DownloadCMakeCM.cmake")
-file(DOWNLOAD "${DOWNLOAD_CMAKECM_URL}"
-              "${CMAKE_BINARY_DIR}/cmake/CMakeCM/DownloadCMakeCM.cmake"
-              INACTIVITY_TIMEOUT 5
-              TIMEOUT 1
-              EXPECTED_HASH SHA256=${DOWNLOAD_CMAKECM_SHA256})
+file(DOWNLOAD "${DOWNLOAD_CMAKECM_URL}" "${CMAKE_BINARY_DIR}/cmake/CMakeCM/DownloadCMakeCM.cmake" INACTIVITY_TIMEOUT 5 TIMEOUT 1 EXPECTED_HASH SHA256=${DOWNLOAD_CMAKECM_SHA256})
 include(${CMAKE_BINARY_DIR}/cmake/CMakeCM/DownloadCMakeCM.cmake)
 
 # Install Common utilities from CMakeCM
 include(Common)
+include(Formatters)
 
 default_install_prefix("${CMAKE_SOURCE_DIR}/bin")
 cxx_14()
@@ -31,23 +28,21 @@ option(BUILD_TESTS "Build the test" ON)
 option(BUILD_APPS "Build the apps" ON)
 option(BUILD_DOCS "Build the docs" ON)
 
-
-## Version of the data
+# Version of the data
 set(DATA_FORMAT_VERSION "13" CACHE STRING "Version of the data format")
 
-
-if (BUILD_ROOT_INTERFACE)
+if(BUILD_ROOT_INTERFACE)
   message(STATUS "Build with ROOT")
   list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS})
   find_package(ROOT REQUIRED COMPONENTS Tree)
-  ## Is mainly the most important PROPERTY
+  # Is mainly the most important PROPERTY
   get_property(ROOT_CXX_STANDARD TARGET ROOT::Core PROPERTY INTERFACE_COMPILE_FEATURES)
-    if(${ROOT_CXX_STANDARD} STREQUAL "cxx_std_14")
-      set( CMAKE_CXX_STANDARD 14 )
-    elseif(${ROOT_CXX_STANDARD} STREQUAL "cxx_std_17")
-      set( CMAKE_CXX_STANDARD 17 )
-    elseif(${ROOT_CXX_STANDARD} STREQUAL "cxx_std_20")
-      set( CMAKE_CXX_STANDARD 20 )
+  if(${ROOT_CXX_STANDARD} STREQUAL "cxx_std_14")
+    set(CMAKE_CXX_STANDARD 14)
+  elseif(${ROOT_CXX_STANDARD} STREQUAL "cxx_std_17")
+    set(CMAKE_CXX_STANDARD 17)
+  elseif(${ROOT_CXX_STANDARD} STREQUAL "cxx_std_20")
+    set(CMAKE_CXX_STANDARD 20)
   endif()
 endif()
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -4,90 +4,69 @@ if(NOT DOXYGEN_FOUND)
   return()
 endif()
 
-  set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-  set(DOXYFILE    ${PROJECT_BINARY_DIR}/docs/Doxyfile)
+set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+set(DOXYFILE ${PROJECT_BINARY_DIR}/docs/Doxyfile)
 
-  
-  set( doxy_latex_index_file ${CMAKE_INSTALL_PREFIX}/docs/refman.pdf)
-  
-  #Options passed to Doxyfile.in
-  set(DOXYGEN_DOXYFILE_ENCODING "UTF-8")
-  set(DOXYGEN_PROJECT_LOGO "")
-  #PROJECT_NAME           = @PROJECT_NAME@
-  #PROJECT_NUMBER         = @PROJECT_VERSION@
-  #PROJECT_BRIEF          = @PROJECT_DESCRIPTION@
-  set(DOXYGEN_OUTPUT_DIRECTORY     ${CMAKE_CURRENT_BINARY_DIR})
-  set(DOXYGEN_CREATE_SUBDIRS "NO") #Default NO
-  set(DOXYGEN_ALLOW_UNICODE_NAMES "YES") #Default NO
-  set(DOXYGEN_OUTPUT_LANGUAGE "English")
-  set(DOXYGEN_OUTPUT_TEXT_DIRECTION "None")
-  
-  
-  
-  
-  set(DOXYGEN_BRIEF_MEMBER_DESC "YES")
-  
-  
-  
-  set(DOXYGEN_GENERATE_LATEX "YES")
-  set(DOXYGEN_LATEX_OUTPUT "latex")
-  if(DOXYGEN_GENERATE_LATEX)
-    set(DOXYGEN_OUPUTS_LATEX "${CMAKE_CURRENT_BINARY_DIR}/${DOXYGEN_LATEX_OUTPUT}/refman.tex")
-  endif()
-  
-  
-  
-  set(DOXYGEN_GENERATE_HTML "YES")
-  set(DOXYGEN_HTML_OUTPUT "html")
-  set(DOXYGEN_HTML_FILE_EXTENSION ".html")
-  if(DOXYGEN_GENERATE_HTML)
-    set(DOXYGEN_OUPUTS_HTML "${CMAKE_CURRENT_BINARY_DIR}/${DOXYGEN_HTML_OUTPUT}/index${DOXYGEN_HTML_FILE_EXTENSION}")
-  endif()
-  
-  
-  set( DOXYGEN_INPUT          ${PROJECT_SOURCE_DIR}/libs)
- # SET( doxy_extra_files     ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.dox) # Pasted into Doxyfile.in
+set(doxy_latex_index_file ${CMAKE_INSTALL_PREFIX}/docs/refman.pdf)
 
-  if(DOXYGEN_GENERATE_LATEX)
-    find_package(LATEX COMPONENTS PDFLATEX)
-    if(NOT LATEX_PDFLATEX_FOUND)
-      message(ERROR "PdfLaTeX is needed to build the latex documentation.")
-      set(DOXYGEN_GENERATE_LATEX "NO")
-    else()
-      set(DOXYGEN_LATEX_CMD_NAME ${PDFLATEX_COMPILER})
-    endif()
+# Options passed to Doxyfile.in
+set(DOXYGEN_DOXYFILE_ENCODING "UTF-8")
+set(DOXYGEN_PROJECT_LOGO "")
+# PROJECT_NAME           = @PROJECT_NAME@ PROJECT_NUMBER         = @PROJECT_VERSION@ PROJECT_BRIEF          = @PROJECT_DESCRIPTION@
+set(DOXYGEN_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+set(DOXYGEN_CREATE_SUBDIRS "NO") # Default NO
+set(DOXYGEN_ALLOW_UNICODE_NAMES "YES") # Default NO
+set(DOXYGEN_OUTPUT_LANGUAGE "English")
+set(DOXYGEN_OUTPUT_TEXT_DIRECTION "None")
+
+set(DOXYGEN_BRIEF_MEMBER_DESC "YES")
+
+set(DOXYGEN_GENERATE_LATEX "YES")
+set(DOXYGEN_LATEX_OUTPUT "latex")
+if(DOXYGEN_GENERATE_LATEX)
+  set(DOXYGEN_OUPUTS_LATEX "${CMAKE_CURRENT_BINARY_DIR}/${DOXYGEN_LATEX_OUTPUT}/refman.tex")
+endif()
+
+set(DOXYGEN_GENERATE_HTML "YES")
+set(DOXYGEN_HTML_OUTPUT "html")
+set(DOXYGEN_HTML_FILE_EXTENSION ".html")
+if(DOXYGEN_GENERATE_HTML)
+  set(DOXYGEN_OUPUTS_HTML "${CMAKE_CURRENT_BINARY_DIR}/${DOXYGEN_HTML_OUTPUT}/index${DOXYGEN_HTML_FILE_EXTENSION}")
+endif()
+
+set(DOXYGEN_INPUT ${PROJECT_SOURCE_DIR}/libs)
+# SET( doxy_extra_files     ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.dox) # Pasted into Doxyfile.in
+
+if(DOXYGEN_GENERATE_LATEX)
+  find_package(LATEX COMPONENTS PDFLATEX)
+  if(NOT LATEX_PDFLATEX_FOUND)
+    message(ERROR "PdfLaTeX is needed to build the latex documentation.")
+    set(DOXYGEN_GENERATE_LATEX "NO")
+  else()
+    set(DOXYGEN_LATEX_CMD_NAME ${PDFLATEX_COMPILER})
   endif()
-  
-  configure_file( ${DOXYFILE_IN} ${DOXYFILE} @ONLY )
-  
-  
+endif()
+
+configure_file(${DOXYFILE_IN} ${DOXYFILE} @ONLY)
+
+add_custom_command(OUTPUT ${DOXYGEN_OUPUTS_HTML} ${DOXYGEN_OUPUTS_LATEX} ${DOXYFILE} COMMAND Doxygen::doxygen ${DOXYFILE} BYPRODUCTS ${DOXYFILE} MAIN_DEPENDENCY ${DOXYFILE_IN} COMMENT "Running Doxygen")
+add_custom_target(doc ALL DEPENDS ${DOXYGEN_OUPUTS_HTML} ${DOXYGEN_OUPUTS_LATEX})
+
+if(DOXYGEN_GENERATE_HTML)
+  install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html" DESTINATION "${CMAKE_INSTALL_PREFIX}/docs" MESSAGE_NEVER)
+endif()
+
+if(DOXYGEN_GENERATE_LATEX)
   add_custom_command(
-    OUTPUT ${DOXYGEN_OUPUTS_HTML} ${DOXYGEN_OUPUTS_LATEX} ${DOXYFILE}
-    COMMAND Doxygen::doxygen ${DOXYFILE}
-    BYPRODUCTS ${DOXYFILE}
-    MAIN_DEPENDENCY ${DOXYFILE_IN}
-    COMMENT "Running Doxygen"
-  )
-  add_custom_target(doc ALL DEPENDS ${DOXYGEN_OUPUTS_HTML} ${DOXYGEN_OUPUTS_LATEX})
-
-  if(DOXYGEN_GENERATE_HTML)
-    install( DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html" DESTINATION "${CMAKE_INSTALL_PREFIX}/docs" MESSAGE_NEVER )
-  endif()
-  
-  if(DOXYGEN_GENERATE_LATEX)
-    add_custom_command(
     OUTPUT ${doxy_latex_index_file}
     COMMAND ${PDFLATEX_COMPILER} -interaction=batchmode -draftmode ${DOXYGEN_OUPUTS_LATEX}
-    COMMAND ${PDFLATEX_COMPILER} -interaction=batchmode ${DOXYGEN_OUPUTS_LATEX} 
+    COMMAND ${PDFLATEX_COMPILER} -interaction=batchmode ${DOXYGEN_OUPUTS_LATEX}
     BYPRODUCTS ${DOXYGEN_OUPUTS_LATEX}
     MAIN_DEPENDENCY ${DOXYGEN_OUPUTS_LATEX}
     DEPENDS doc
     COMMENT "Generating Latex documentation"
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/latex/
-   )
-    add_custom_target(doc_latex ALL DEPENDS ${doxy_latex_index_file})
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf DESTINATION "${CMAKE_INSTALL_PREFIX}/docs" RENAME ${PROJECT_NAME}Manual.pdf)
-  endif()
-
-
-  
+    )
+  add_custom_target(doc_latex ALL DEPENDS ${doxy_latex_index_file})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/latex/refman.pdf DESTINATION "${CMAKE_INSTALL_PREFIX}/docs" RENAME ${PROJECT_NAME}Manual.pdf)
+endif()

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -1,10 +1,4 @@
-add_library(core 
-            src/DIFSlowControl.cc 
-            src/DIFUnpacker.cc
-            src/SDHCAL_buffer.cc
-            src/SDHCAL_buffer_LoopCounter.cc
-            src/SDHCAL_RawBuffer_Navigator.cc
-           )
+add_library(core src/DIFSlowControl.cc src/DIFUnpacker.cc src/SDHCAL_buffer.cc src/SDHCAL_buffer_LoopCounter.cc src/SDHCAL_RawBuffer_Navigator.cc)
 target_include_directories(core PUBLIC include)
 target_compile_definitions(core PRIVATE "-DDATA_FORMAT_VERSION=${DATA_FORMAT_VERSION}")
 install(TARGETS core RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include)

--- a/libs/interface/CMakeLists.txt
+++ b/libs/interface/CMakeLists.txt
@@ -1,17 +1,13 @@
 # standard
-add_library(standard
-            standard/src/textDump.cc
-           )
+add_library(standard standard/src/textDump.cc)
 target_include_directories(standard PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/standard/include")
 target_link_libraries(standard PUBLIC core)
 install(TARGETS standard RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include)
 
 if(BUILD_ROOT_INTERFACE)
-  add_library(root
-              "${CMAKE_CURRENT_SOURCE_DIR}/root/src/ROOTtreeDest.cc"
-             )
+  add_library(root "${CMAKE_CURRENT_SOURCE_DIR}/root/src/ROOTtreeDest.cc")
   target_include_directories(root PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/root/include" PUBLIC ${ROOT_INCLUDE_DIRS})
-  target_link_libraries(root PUBLIC core PUBLIC ${ROOT_LIBRARIES} )
+  target_link_libraries(root PUBLIC core PUBLIC ${ROOT_LIBRARIES})
   install(TARGETS root RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include)
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,14 +9,14 @@ target_link_libraries(test_exe PRIVATE standard PRIVATE DIFdataExample PRIVATE s
 install(TARGETS test_exe RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include)
 add_test(NAME test_exe COMMAND test_exe)
 
-if (BUILD_ROOT_INTERFACE)
+if(BUILD_ROOT_INTERFACE)
   add_executable(test_root_exe main_test_root_exe.cc)
   target_link_libraries(test_root_exe PRIVATE root PRIVATE DIFdataExample PRIVATE streamout::CLI11)
   install(TARGETS test_root_exe RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include)
   add_test(NAME test_root_exe COMMAND test_root_exe)
 endif()
 
-if (BUILD_LCIO_INTERFACE)
+if(BUILD_LCIO_INTERFACE)
   add_executable(test_lcio_exe main_test_lcio_exe.cc)
   target_link_libraries(test_lcio_exe PRIVATE streamout::LCIO PRIVATE DIFdataExample PRIVATE streamout::CLI11)
   install(TARGETS test_lcio_exe RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib PUBLIC_HEADER DESTINATION include)


### PR DESCRIPTION
Hi,

CMakeCM now can help you to format your code if you have clang-format and/or cmake-format installed in your computer...
Nothing very hard to do it is taking care of everything 👍🏻 

make format  : Shows which files are affected by clang-format and/or cmake-format
make check-format : Errors if files are affected by clang-format and/or cmake-format (for CI integration)
make fix-format : Applies clang-format and/or cmake-format to all affected files

It will explain how to activate this on configure step.
